### PR TITLE
Tweaks to add rbac for pre-sync SA, switch flant5 PVC to default (RWO)

### DIFF
--- a/bootstrap/applicationset/applicationset-bootstrap.yaml
+++ b/bootstrap/applicationset/applicationset-bootstrap.yaml
@@ -8,6 +8,11 @@ spec:
     - list:
         elements:
           - cluster: in-cluster
+            name: ic-rhoai-operator
+            repoURL: https://github.com/redhat-et/parasol-insurance.git
+            targetRevision: main-rhoai-2.13
+            path: bootstrap/ic-rhoai-operator
+          - cluster: in-cluster
             name: ic-rhoai-configuration
             repoURL: https://github.com/redhat-et/parasol-insurance.git
             targetRevision: main-rhoai-2.13

--- a/bootstrap/ic-rhoai-operator/kustomization.yaml
+++ b/bootstrap/ic-rhoai-operator/kustomization.yaml
@@ -3,10 +3,10 @@ kind: Kustomization
 
 resources:
   # wave 0
-  - namespace.yaml
-  # wave 1
+#  - namespace.yaml
+  # wave 0
   - rbac-presync-monitoring.yaml
-  - subscription-authorino.yaml
+#  - subscription-authorino.yaml
   # wave 2
-  - operator-group.yaml
-  - subscription.yaml
+#  - operator-group.yaml
+#  - subscription.yaml

--- a/bootstrap/ic-shared-llm/pvc-hftgi.yaml
+++ b/bootstrap/ic-shared-llm/pvc-hftgi.yaml
@@ -9,8 +9,8 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "2"
 spec:
-  accessModes:
-    - ReadWriteMany
+#  accessModes:
+#    - ReadWriteMany
   resources:
     requests:
       storage: 10Gi


### PR DESCRIPTION
Tweaks to add rbac for pre-sync SA, switch flant5 PVC to default (RWO)